### PR TITLE
chore: update Python version to 3.14 in workflow files and configuration

### DIFF
--- a/.github/workflows/check_pr_release_notes.yml
+++ b/.github/workflows/check_pr_release_notes.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Check presence of release notes in PR description
         uses: AbsaOSS/release-notes-presence-check@8e586b26a5e27f899ee8590a5d988fd4780a3dbf

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
-          python-version: '3.12'
+          python-version: '3.14'
           cache: 'pip'
 
       - name: Install dependencies

--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Check Format of Received Tag
         id: check-version-tag

--- a/.github/workflows/static_analysis_and_tests.yml
+++ b/.github/workflows/static_analysis_and_tests.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548
         with:
-          python-version: '3.12'
+          python-version: '3.14'
           cache: 'pip'
 
       - name: Install dependencies
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548
         with:
-          python-version: '3.12'
+          python-version: '3.14'
           cache: 'pip'
 
       - name: Install dependencies
@@ -92,7 +92,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548
         with:
-          python-version: '3.12'
+          python-version: '3.14'
           cache: 'pip'
 
       - name: Install dependencies
@@ -117,7 +117,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548
         with:
-          python-version: '3.12'
+          python-version: '3.14'
           cache: 'pip'
 
       - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,4 +8,5 @@ omit = ["tests/*"]
 
 [tool.mypy]
 check_untyped_defs = true
+python_version = "3.14"
 exclude = "tests"


### PR DESCRIPTION
## Overview
Move repo to support python 3.14.

## Release Notes
- Update to python 3.14.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python runtime version from 3.12/3.13 to 3.14 across CI/CD workflows and development tooling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->